### PR TITLE
Add 'Hide unsafe lunches' filter method

### DIFF
--- a/app/components/MenuVariant.vue
+++ b/app/components/MenuVariant.vue
@@ -38,13 +38,31 @@ export default defineNuxtComponent({
           item,
           isFiltered: this.isFiltered(item.diets),
         };
-      }).filter(i => !this.filterHide || !this.hasFilters || i.isFiltered);
+      }).filter((i) => {
+        // hideLunch: show all items if ALL match, show none if ANY doesn't match
+        if (this.filterHideLunch && this.hasFilters) {
+          return this.allItemsMatch;
+        }
+        // hide: show only matching items
+        if (this.filterHide && this.hasFilters) {
+          return i.isFiltered;
+        }
+        // highlight (or no filters): show all items
+        return true;
+      });
     },
     hasFilters() {
       return Object.values(this.filters.filters).some(v => v);
     },
     filterHide() {
       return this.filters.method === 'hide';
+    },
+    filterHideLunch() {
+      return this.filters.method === 'hideLunch';
+    },
+    allItemsMatch() {
+      if (!this.hasFilters) return true;
+      return this.menu.items.every(item => this.isFiltered(item.diets));
     },
     /// Returns the menu name split into appropriate length parts
     menuNameParts(): string[] {

--- a/app/components/OptionsMenu.vue
+++ b/app/components/OptionsMenu.vue
@@ -95,6 +95,7 @@ export default defineNuxtComponent({
       return [
         { value: 'highlight', label: this.$t('filters.highlight') },
         { value: 'hide', label: this.$t('filters.hide') },
+        { value: 'hideLunch', label: this.$t('filters.hideLunch') },
       ];
     },
     isFiltered() {

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -8,5 +8,5 @@ export interface FilterConfig {
     recommended: boolean;
     [key: string]: boolean;
   };
-  method: 'highlight' | 'hide';
+  method: 'highlight' | 'hide' | 'hideLunch';
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -36,6 +36,7 @@
     "method": "Select filter method",
     "highlight": "Highlight",
     "hide": "Hide others",
+    "hideLunch": "Hide unsafe lunches",
     "order": "Order (drag and drop)"
   },
   "restaurant": {

--- a/i18n/locales/fi.json
+++ b/i18n/locales/fi.json
@@ -36,6 +36,7 @@
     "method": "Valitse suodatustapa",
     "highlight": "Korosta",
     "hide": "Piilota muut",
+    "hideLunch": "Piilota sopimattomat lounaat",
     "order": "Järjestys (vedä ja pudota)"
   },
   "restaurant": {


### PR DESCRIPTION
Adds a third filter method that hides entire lunch sections (e.g., Keittolounas) if ANY item in that lunch lacks the required dietary tag. Useful for users with strict dietary requirements who need to avoid lunches containing non-compliant items.